### PR TITLE
Update textureGather.xhtml

### DIFF
--- a/sl4/textureGather.xhtml
+++ b/sl4/textureGather.xhtml
@@ -244,7 +244,7 @@
         <pre class="programlisting">    vec4(Sample_i0_j1(P, base).comp,
          Sample_i1_j1(P, base).comp,
          Sample_i1_j0(P, base).comp,
-         Sample_i0_j1(P, base).comp);</pre>
+         Sample_i0_j0(P, base).comp);</pre>
         <p>
     </p>
         <p>


### PR DESCRIPTION
From #48
Return value is now correct at last position, according to the Description in the [specification](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/textureGather.xhtml)

from: 
```
vec4(Sample_i0_j1(P, base).comp,
         Sample_i1_j1(P, base).comp,
         Sample_i1_j0(P, base).comp,
         Sample_i0_j1(P, base).comp);
```

to:
```
vec4(Sample_i0_j1(P, base).comp,
         Sample_i1_j1(P, base).comp,
         Sample_i1_j0(P, base).comp,
         Sample_i0_j0(P, base).comp);
```